### PR TITLE
Add Scriptrunner web panel example

### DIFF
--- a/scriptrunner_example/README.md
+++ b/scriptrunner_example/README.md
@@ -1,0 +1,8 @@
+# Scriptrunner Web Panel Example
+
+This folder contains a sample Groovy script for an Atlassian Scriptrunner Web Panel.
+The script `web-panel.groovy` renders Markdown text inside a panel using Atlassian's
+AUI CSS classes.
+
+Add this script when configuring a Web Panel through **Script Fragments** in
+Scriptrunner and the panel will display formatted Markdown content.

--- a/scriptrunner_example/web-panel.groovy
+++ b/scriptrunner_example/web-panel.groovy
@@ -1,0 +1,30 @@
+import com.atlassian.sal.api.component.ComponentLocator
+import com.atlassian.webresource.api.assembler.PageBuilderService
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
+
+// Require Atlassian AUI resources so the panel uses the default styling
+PageBuilderService pageBuilderService = ComponentLocator.getComponent(PageBuilderService)
+pageBuilderService.assembler().resources().requireWebResource("com.atlassian.auiplugin:aui-css")
+
+// Markdown text to display in the panel
+String markdownText = """
+# Sample Web Panel
+
+This panel is rendered from **Markdown** using the CommonMark parser.
+
+* Item 1
+* Item 2
+"""
+
+Parser parser = Parser.builder().build()
+HtmlRenderer renderer = HtmlRenderer.builder().build()
+String htmlContent = renderer.render(parser.parse(markdownText))
+
+return """
+<div class='aui-page-panel'>
+  <section class='aui-page-panel-content'>
+    ${htmlContent}
+  </section>
+</div>
+"""


### PR DESCRIPTION
## Summary
- add a `scriptrunner_example` directory with a sample web panel script
- show how to render Markdown using Atlassian AUI styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854fbab59b48330942fdfad2a740a29