### PR TITLE
Switch example to Jira wiki syntax

### DIFF
--- a/scriptrunner_example/README.md
+++ b/scriptrunner_example/README.md
@@ -1,8 +1,9 @@
 # Scriptrunner Web Panel Example
 
 This folder contains a sample Groovy script for an Atlassian Scriptrunner Web Panel.
-The script `web-panel.groovy` renders Markdown text inside a panel using Atlassian's
-AUI CSS classes.
+The script `web-panel.groovy` renders Jira *wiki markup* inside a panel using Atlassian's
+AUI CSS classes. Wiki text is converted to HTML using Jira's built-in renderer
+so no additional dependencies are required.
 
 Add this script when configuring a Web Panel through **Script Fragments** in
-Scriptrunner and the panel will display formatted Markdown content.
+Scriptrunner and the panel will display formatted wiki content.

--- a/scriptrunner_example/web-panel.groovy
+++ b/scriptrunner_example/web-panel.groovy
@@ -1,25 +1,25 @@
 import com.atlassian.sal.api.component.ComponentLocator
 import com.atlassian.webresource.api.assembler.PageBuilderService
-import org.commonmark.parser.Parser
-import org.commonmark.renderer.html.HtmlRenderer
+
+import com.atlassian.jira.component.ComponentAccessor
+import com.atlassian.jira.issue.fields.renderer.RendererManager
 
 // Require Atlassian AUI resources so the panel uses the default styling
 PageBuilderService pageBuilderService = ComponentLocator.getComponent(PageBuilderService)
 pageBuilderService.assembler().resources().requireWebResource("com.atlassian.auiplugin:aui-css")
 
-// Markdown text to display in the panel
-String markdownText = """
-# Sample Web Panel
+// Wiki markup text to display in the panel
+String wikiText = """
+h1. Sample Web Panel
 
-This panel is rendered from **Markdown** using the CommonMark parser.
+This panel is rendered from *Jira* wiki syntax.
 
 * Item 1
 * Item 2
 """
 
-Parser parser = Parser.builder().build()
-HtmlRenderer renderer = HtmlRenderer.builder().build()
-String htmlContent = renderer.render(parser.parse(markdownText))
+RendererManager rendererManager = ComponentAccessor.getComponent(RendererManager)
+String htmlContent = rendererManager.getRendererForType("atlassian-wiki-renderer").render(wikiText, null)
 
 return """
 <div class='aui-page-panel'>


### PR DESCRIPTION
## Summary
- document wiki markup usage in README
- render Jira wiki text in the web panel script using RendererManager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854fd8780548330a7097d47751f2f94